### PR TITLE
export: allow interacting with configured APIs

### DIFF
--- a/cli/export.go
+++ b/cli/export.go
@@ -15,7 +15,8 @@ func SetApiConfig(c ApiConfigs) {
 	configs = c
 }
 
-func GetApplianceConfigs() ApiConfigs {
+// GetAPIConfigs returns the map of configs
+func GetAPIConfigs() ApiConfigs {
 	return configs
 }
 
@@ -127,14 +128,14 @@ func IsVerbose() bool {
 }
 
 // InteractiveConfigure calls the internal configure function
-func InteractiveConfigure() func(cmd *cobra.Command, args []string) {
-	return askInitAPIDefault
+func InteractiveConfigure(cmd *cobra.Command, args []string) {
+	askInitAPIDefault(cmd, args)
 }
 
 func GetAuthHandlers(name string) (AuthHandler, error) {
 	auth, ok := authHandlers[name]
 	if !ok {
-		return nil, fmt.Errorf("corresponding authenthication handler missing")
+		return nil, fmt.Errorf("corresponding authentication handler missing")
 	}
 	return auth, nil
 }

--- a/cli/export.go
+++ b/cli/export.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/logrusorgru/aurora"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -127,4 +129,12 @@ func IsVerbose() bool {
 // InteractiveConfigure calls the internal configure function
 func InteractiveConfigure() func(cmd *cobra.Command, args []string) {
 	return askInitAPIDefault
+}
+
+func GetAuthHandlers(name string) (AuthHandler, error) {
+	auth, ok := authHandlers[name]
+	if !ok {
+		return nil, fmt.Errorf("corresponding authenthication handler missing")
+	}
+	return auth, nil
 }

--- a/cli/export.go
+++ b/cli/export.go
@@ -10,8 +10,8 @@ import (
 
 type ApiConfigs = apiConfigs
 
-// SetApiConfig sets the configs.
-func SetApiConfig(c ApiConfigs) {
+// SetApiConfigs sets the configs.
+func SetApiConfigs(c ApiConfigs) {
 	configs = c
 }
 
@@ -49,20 +49,10 @@ func GetCurrentConfig() *APIConfig {
 	return currentConfig
 }
 
-// AddDefaultConfig adds the "https://localhost:443" to configs at runtime, does not modify the
+// AddConfig adds a config to configs at runtime, does not modify the
 // persistent config file
-func AddDefaultConfig() {
-	configs["default"] = &APIConfig{
-		name:     "default",
-		Base:     "https://localhost:443",
-		Profiles: map[string]*APIProfile{},
-		TLS: &TLSConfig{
-			InsecureSkipVerify: viper.GetBool("rsh-insecure"),
-			Cert:               viper.GetString("rsh-client-cert"),
-			Key:                viper.GetString("rsh-client-key"),
-			CACert:             viper.GetString("rsh-ca-cert"),
-		},
-	}
+func AddConfig(cfg *APIConfig) {
+	configs[cfg.name] = cfg
 }
 
 // SetTTY sets the tty.

--- a/cli/export.go
+++ b/cli/export.go
@@ -30,18 +30,18 @@ func (a *APIConfig) GetName() string {
 	return a.name
 }
 
-// SetViper sets the restish viper variable
-func SetViper(v *viper.Viper) {
+// SetApis sets the restish apis viper variable
+func SetApis(v *viper.Viper) {
 	apis = v
 }
 
 // SetCurrentConfig sets the currentConfig.
-func SetCurrentConfig(apiName string) bool {
+func SetCurrentConfig(apiName string) error {
 	if cfg, ok := configs[apiName]; ok {
 		currentConfig = cfg
-		return true
+		return nil
 	}
-	return false
+	return fmt.Errorf("no matching config found")
 }
 
 // GetCurrentConfig returns the currently set APIConfig

--- a/cli/export.go
+++ b/cli/export.go
@@ -46,6 +46,22 @@ func GetCurrentConfig() *APIConfig {
 	return currentConfig
 }
 
+// AddDefaultConfig adds the "https://localhost:443" to configs at runtime, does not modify the
+// persistent config file
+func AddDefaultConfig() {
+	configs["default"] = &APIConfig{
+		name:     "default",
+		Base:     "https://localhost:443",
+		Profiles: map[string]*APIProfile{},
+		TLS: &TLSConfig{
+			InsecureSkipVerify: viper.GetBool("rsh-insecure"),
+			Cert:               viper.GetString("rsh-client-cert"),
+			Key:                viper.GetString("rsh-client-key"),
+			CACert:             viper.GetString("rsh-ca-cert"),
+		},
+	}
+}
+
 // SetTTY sets the tty.
 func SetTTY(b bool) {
 	tty = b

--- a/cli/export.go
+++ b/cli/export.go
@@ -2,13 +2,19 @@ package cli
 
 import (
 	"github.com/logrusorgru/aurora"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
-type ApiConfigs = apiConfigs
+type ApplianceConfigs = apiConfigs
 
 // SetApiConfig sets the configs.
-func SetApiConfig(c ApiConfigs) {
+func SetApiConfig(c ApplianceConfigs) {
 	configs = c
+}
+
+func GetApplianceConfigs() ApplianceConfigs {
+	return configs
 }
 
 // SetName sets the name of the APIConfig.
@@ -16,11 +22,28 @@ func (a *APIConfig) SetName(name string) {
 	a.name = name
 }
 
+// GetName returns the name of the APIConfig
+func (a *APIConfig) GetName() string {
+	return a.name
+}
+
+// SetViper sets the restish viper variable
+func SetViper(v *viper.Viper) {
+	apis = v
+}
+
 // SetCurrentConfig sets the currentConfig.
-func SetCurrentConfig(apiName string) {
+func SetCurrentConfig(apiName string) bool {
 	if cfg, ok := configs[apiName]; ok {
 		currentConfig = cfg
+		return true
 	}
+	return false
+}
+
+// GetCurrentConfig returns the currently set APIConfig
+func GetCurrentConfig() *APIConfig {
+	return currentConfig
 }
 
 // SetTTY sets the tty.
@@ -84,4 +107,9 @@ func EnableVerbose() {
 // IsVerbose returns the state of the internal enableVerbose boolean.
 func IsVerbose() bool {
 	return enableVerbose
+}
+
+// GetInteractiveConfigureClosure exposes the internal configure function
+func GetInteractiveConfigureClosure() func(cmd *cobra.Command, args []string) {
+	return askInitAPIDefault
 }

--- a/cli/export.go
+++ b/cli/export.go
@@ -6,14 +6,14 @@ import (
 	"github.com/spf13/viper"
 )
 
-type ApplianceConfigs = apiConfigs
+type ApiConfigs = apiConfigs
 
 // SetApiConfig sets the configs.
-func SetApiConfig(c ApplianceConfigs) {
+func SetApiConfig(c ApiConfigs) {
 	configs = c
 }
 
-func GetApplianceConfigs() ApplianceConfigs {
+func GetApplianceConfigs() ApiConfigs {
 	return configs
 }
 

--- a/cli/export.go
+++ b/cli/export.go
@@ -84,9 +84,8 @@ func EditRequest(
 	edit(addr, args, interactive, noPrompt, exitFunc, editMarshal, editUnmarshal, ext)
 }
 
-// InitConfig calls the internal initConfig function.
-func InitConfig(appName string) {
-	initConfig(appName, "")
+func UserHomeDir() string {
+	return userHomeDir()
 }
 
 // InitCache calls the internal initCache function.
@@ -109,7 +108,7 @@ func IsVerbose() bool {
 	return enableVerbose
 }
 
-// GetInteractiveConfigureClosure exposes the internal configure function
-func GetInteractiveConfigureClosure() func(cmd *cobra.Command, args []string) {
+// InteractiveConfigure calls the internal configure function
+func InteractiveConfigure() func(cmd *cobra.Command, args []string) {
 	return askInitAPIDefault
 }


### PR DESCRIPTION
Extend the export part of restish to be used as a library. The changes allow the library usage of restish to configure APIs and set the currently selected one.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anapaya/restish/2)
<!-- Reviewable:end -->
