### PR TITLE
export: unused currentConfig wrappers

### DIFF
--- a/cli/export.go
+++ b/cli/export.go
@@ -35,20 +35,6 @@ func SetApis(v *viper.Viper) {
 	apis = v
 }
 
-// SetCurrentConfig sets the currentConfig.
-func SetCurrentConfig(apiName string) error {
-	if cfg, ok := configs[apiName]; ok {
-		currentConfig = cfg
-		return nil
-	}
-	return fmt.Errorf("no matching config found")
-}
-
-// GetCurrentConfig returns the currently set APIConfig
-func GetCurrentConfig() *APIConfig {
-	return currentConfig
-}
-
 // AddConfig adds a config to configs at runtime, does not modify the
 // persistent config file
 func AddConfig(cfg *APIConfig) {


### PR DESCRIPTION
The exported functions are not used anymore as the `currentConfig` is only used for the auto-completion of endpoints which we moved out of this repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/anapaya/restish/4)
<!-- Reviewable:end -->
