### PR TITLE
rebase: upgrade fork

### DIFF
--- a/cli/export.go
+++ b/cli/export.go
@@ -1,14 +1,23 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/logrusorgru/aurora"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 type ApiConfigs = apiConfigs
 
-// SetApiConfig sets the configs.
-func SetApiConfig(c ApiConfigs) {
+// SetApiConfigs sets the configs.
+func SetApiConfigs(c ApiConfigs) {
 	configs = c
+}
+
+// GetAPIConfigs returns the map of configs
+func GetAPIConfigs() ApiConfigs {
+	return configs
 }
 
 // SetName sets the name of the APIConfig.
@@ -16,11 +25,34 @@ func (a *APIConfig) SetName(name string) {
 	a.name = name
 }
 
+// GetName returns the name of the APIConfig
+func (a *APIConfig) GetName() string {
+	return a.name
+}
+
+// SetApis sets the restish apis viper variable
+func SetApis(v *viper.Viper) {
+	apis = v
+}
+
 // SetCurrentConfig sets the currentConfig.
-func SetCurrentConfig(apiName string) {
+func SetCurrentConfig(apiName string) error {
 	if cfg, ok := configs[apiName]; ok {
 		currentConfig = cfg
+		return nil
 	}
+	return fmt.Errorf("no matching config found")
+}
+
+// GetCurrentConfig returns the currently set APIConfig
+func GetCurrentConfig() *APIConfig {
+	return currentConfig
+}
+
+// AddConfig adds a config to configs at runtime, does not modify the
+// persistent config file
+func AddConfig(cfg *APIConfig) {
+	configs[cfg.name] = cfg
 }
 
 // SetTTY sets the tty.
@@ -61,9 +93,8 @@ func EditRequest(
 	edit(addr, args, interactive, noPrompt, exitFunc, editMarshal, editUnmarshal, ext)
 }
 
-// InitConfig calls the internal initConfig function.
-func InitConfig(appName string) {
-	initConfig(appName, "")
+func UserHomeDir() string {
+	return userHomeDir()
 }
 
 // InitCache calls the internal initCache function.
@@ -84,4 +115,17 @@ func EnableVerbose() {
 // IsVerbose returns the state of the internal enableVerbose boolean.
 func IsVerbose() bool {
 	return enableVerbose
+}
+
+// InteractiveConfigure calls the internal configure function
+func InteractiveConfigure(cmd *cobra.Command, args []string) {
+	askInitAPIDefault(cmd, args)
+}
+
+func GetAuthHandlers(name string) (AuthHandler, error) {
+	auth, ok := authHandlers[name]
+	if !ok {
+		return nil, fmt.Errorf("corresponding authentication handler missing")
+	}
+	return auth, nil
 }

--- a/cli/export.go
+++ b/cli/export.go
@@ -35,29 +35,15 @@ func SetApis(v *viper.Viper) {
 	apis = v
 }
 
-// SetCurrentConfig sets the currentConfig.
-func SetCurrentConfig(apiName string) error {
-	if cfg, ok := configs[apiName]; ok {
-		currentConfig = cfg
-		return nil
-	}
-	return fmt.Errorf("no matching config found")
-}
-
-// GetCurrentConfig returns the currently set APIConfig
-func GetCurrentConfig() *APIConfig {
-	return currentConfig
-}
-
 // AddConfig adds a config to configs at runtime, does not modify the
 // persistent config file
 func AddConfig(cfg *APIConfig) {
 	configs[cfg.name] = cfg
 }
 
-// SetTTY sets the tty.
-func SetTTY(b bool) {
-	tty = b
+// SetUseColor sets the useColor boolean.
+func SetUseColor(b bool) {
+	useColor = b
 }
 
 // SetAurora sets the aurora.
@@ -68,7 +54,7 @@ func SetAurora(a aurora.Aurora) {
 // ResetRegistries resets the registries used for internal bookkeeping.
 func ResetRegistries() {
 	authHandlers = map[string]AuthHandler{}
-	contentTypes = []contentTypeEntry{}
+	contentTypes = map[string]contentTypeEntry{}
 	encodings = map[string]ContentEncoding{}
 	linkParsers = []LinkParser{}
 	loaders = []Loader{}

--- a/cli/export.go
+++ b/cli/export.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"github.com/logrusorgru/aurora"
+)
+
+type ApiConfigs = apiConfigs
+
+// SetApiConfig sets the configs.
+func SetApiConfig(c ApiConfigs) {
+	configs = c
+}
+
+// SetName sets the name of the APIConfig.
+func (a *APIConfig) SetName(name string) {
+	a.name = name
+}
+
+// SetCurrentConfig sets the currentConfig.
+func SetCurrentConfig(apiName string) {
+	if cfg, ok := configs[apiName]; ok {
+		currentConfig = cfg
+	}
+}
+
+// SetTTY sets the tty.
+func SetTTY(b bool) {
+	tty = b
+}
+
+// SetAurora sets the aurora.
+func SetAurora(a aurora.Aurora) {
+	au = a
+}
+
+// ResetRegistries resets the registries used for internal bookkeeping.
+func ResetRegistries() {
+	authHandlers = map[string]AuthHandler{}
+	contentTypes = []contentTypeEntry{}
+	encodings = map[string]ContentEncoding{}
+	linkParsers = []LinkParser{}
+	loaders = []Loader{}
+}
+
+// GetGenericClosure exposes the internal generic function.
+func GetGenericClosure() func(method string, addr string, args []string) {
+	return generic
+}
+
+// GetEditClosure exposes the internal edit function.
+func GetEditClosure() func(
+	addr string,
+	args []string,
+	interactive,
+	noPrompt bool,
+	exitFunc func(int),
+	editMarshal func(interface{}) ([]byte, error),
+	editUnmarshal func([]byte, interface{}) error, ext string,
+) {
+	return edit
+}
+
+// InitConfig calls the internal initConfig function.
+func InitConfig(appName string) {
+	initConfig(appName, "")
+}
+
+// InitCache calls the internal initCache function.
+func InitCache(appName string) {
+	initCache(appName)
+}
+
+// MatchTemplate calls the internal matchTemplate function.
+func MatchTemplate(url, template string) string {
+	return matchTemplate(url, template)
+}
+
+// EnableVerbose sets the enableVerbose boolean to true.
+func EnableVerbose() {
+	enableVerbose = true
+}
+
+// IsVerbose returns the state of the internal enableVerbose boolean.
+func IsVerbose() bool {
+	return enableVerbose
+}

--- a/cli/export.go
+++ b/cli/export.go
@@ -42,22 +42,23 @@ func ResetRegistries() {
 	loaders = []Loader{}
 }
 
-// GetGenericClosure exposes the internal generic function.
-func GetGenericClosure() func(method string, addr string, args []string) {
-	return generic
+// GenericRequest exposes the internal generic function.
+func GenericRequest(method string, addr string, args []string) {
+	generic(method, addr, args)
 }
 
-// GetEditClosure exposes the internal edit function.
-func GetEditClosure() func(
+// EditRequest exposes the internal edit function.
+func EditRequest(
 	addr string,
 	args []string,
 	interactive,
 	noPrompt bool,
 	exitFunc func(int),
 	editMarshal func(interface{}) ([]byte, error),
-	editUnmarshal func([]byte, interface{}) error, ext string,
+	editUnmarshal func([]byte, interface{}) error,
+	ext string,
 ) {
-	return edit
+	edit(addr, args, interactive, noPrompt, exitFunc, editMarshal, editUnmarshal, ext)
 }
 
 // InitConfig calls the internal initConfig function.


### PR DESCRIPTION
The shorthand dependency was rewritten in the v2.0.0 upgrade (https://github.com/danielgtaylor/shorthand/releases) which caused some issues beforehand. So we rebase this fork on the latest restish release to include those changes.

Change:
- global tty variable changed to useColor
- removed unused exported functions

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/restish/5)
<!-- Reviewable:end -->
