### PR TITLE
content: add PEM marshal/unmarshal functions

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -670,6 +670,7 @@ func Defaults() {
 	AddContentType("text", "text/*", 0.2, &Text{})
 	AddContentType("table", "", -1, &Table{})
 	AddContentType("readable", "", -1, &Readable{})
+	AddContentType("pem", "application/x-pem-file", 0.9, &PEM{})
 
 	// Add link relation parsers
 	AddLinkParser(&LinkHeaderParser{})

--- a/cli/content.go
+++ b/cli/content.go
@@ -417,3 +417,22 @@ func (r Readable) Marshal(value interface{}) ([]byte, error) {
 func (i Readable) Unmarshal(data []byte, value interface{}) error {
 	return fmt.Errorf("unimplemented")
 }
+
+// PEM describes content types like `application/x-pem-file`
+type PEM struct{}
+
+// Detect if the content type is XPemFile.
+func (x PEM) Detect(contentType string) bool {
+	first := strings.Split(contentType, ";")[0]
+	return first == "application/x-pem-file"
+}
+
+// Marshal the value to encoded PEM.
+func (x PEM) Marshal(value interface{}) ([]byte, error) {
+	return Text{}.Marshal(value)
+}
+
+// Unmarshal the value from encoded PEM.
+func (x PEM) Unmarshal(data []byte, value interface{}) error {
+	return Text{}.Unmarshal(data, value)
+}

--- a/cli/content_test.go
+++ b/cli/content_test.go
@@ -19,6 +19,21 @@ var contentTests = []struct {
 	{"cbor", []string{"application/cbor", "foo+cbor"}, &CBOR{}, []byte("\xf6"), nil},
 	{"msgpack", []string{"application/msgpack", "application/x-msgpack", "application/vnd.msgpack", "foo+msgpack"}, &MsgPack{}, []byte("\x81\xa5\x68\x65\x6c\x6c\x6f\xa5\x77\x6f\x72\x6c\x64"), nil},
 	{"ion", []string{"application/ion", "foo+ion"}, &Ion{}, []byte("\xe0\x01\x00\xea\x0f"), []byte("null")},
+	{"pem", []string{"application/x-pem-file"}, &PEM{}, []byte(`-----BEGIN CERTIFICATE-----
+MIICNjCCAd2gAwIBAgIUIb156ksTUO9QRhMF2ByRzlMtOUUwCgYIKoZIzj0EAwIw
+dDEsMCoGA1UEAxMjQW5hcGF5YSBadXJpY2ggQ1AgQ0EgLSBHRU4gSSAyMDIxLjEx
+CzAJBgNVBAYTAkNIMRswGQYDVQQKExJBbmFwYXlhIFN5c3RlbXMgQUcxGjAYBgsr
+BgEEAYOwHAECARMJNjQtMjowOjEzMB4XDTIzMDgxMzE0NTgyOFoXDTIzMDgxNjE0
+NTg1OFowRjELMAkGA1UEBhMCQ0gxGzAZBgNVBAoTEkFuYXBheWEgU3lzdGVtcyBB
+RzEaMBgGCysGAQQBg7AcAQIBEwk2NC0yOjA6MWEwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAASg9yRvjMeep0lBtdIEbCH1uDkn57ezTe7gUcJT/cNcJoCvAAJlrUpO
+YWd78Ev3MChpN8fvHcNMtqIKJvYa27cpo3sweTAfBgNVHSMEGDAWgBSbySNUc94B
+UBbzChXp3YlXzHuf2DAOBgNVHQ8BAf8EBAMCB4AwJwYDVR0lBCAwHgYIKwYBBQUH
+AwEGCCsGAQUFBwMCBggrBgEFBQcDCDAdBgNVHQ4EFgQUlTfZkFas9fg8fJdHuO9F
+Z5P7r2MwCgYIKoZIzj0EAwIDRwAwRAIgMk+SMPwDJAD4KDJ7OtS6Pv4NjPvqcbGN
+GVeJecGlNVoCIHcjskwpWHmYMnqwWXWK5cgYvtcorioNyFKQFiLaEyx5
+-----END CERTIFICATE-----
+`), nil},
 }
 
 func TestContentTypes(parent *testing.T) {


### PR DESCRIPTION
This commits adds a marshal/unmarshal functionality for PEM content. PEM content is treated as text.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Anapaya/restish/8)
<!-- Reviewable:end -->
